### PR TITLE
Adding a new way of adding authors to the blog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+Ider Delzo(soloidx) <soloidx@gmail.com>
+Jean-Pierre Chauvel(hellhound) <jean.pierre@chauvel.org>
+Nefi Arroyo(nefi) <nefinef@gmail.com>
+Jonathan Bolo(jbolo) <jbolo.des@gmail.com>

--- a/authors.py
+++ b/authors.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+import os
+
+AUTHORS_FILENAME = "AUTHORS"
+AUTHORS_FILEPATH = os.path.join(os.path.dirname(__file__), AUTHORS_FILENAME)
+
+
+def get_authors() -> Tuple[str, str]:
+    with open(AUTHORS_FILEPATH, "r") as fd:
+        for author_line in fd.readlines():
+            tokens = author_line.split("<")
+            email = tokens[1].strip()[:-1]
+            tokens = tokens[0].strip().split("(")
+            name = tokens[0]
+            nickname = tokens[1][:-1]
+            yield (nickname, name, f"mailto:{email}")

--- a/conf.py
+++ b/conf.py
@@ -14,6 +14,8 @@ import ablog
 import alabaster
 import locale
 
+from authors import get_authors
+
 locale.setlocale(locale.LC_ALL, "es_ES.UTF-8")
 
 # -- General ABlog Options ----------------------------------------------------
@@ -38,9 +40,8 @@ blog_baseurl = "blog.python.pe"
 # links. Dictionary keys are what should be used in ``post`` directive
 # to refer to the author.  Default is ``{}``.
 blog_authors = {
-    "hellhound": ("Jean Pierre Chauvel", None),
-    "soloidx": ("Ider Delzo", None),
-    "jbolo": ("Jonathan Bolo", None),
+    nickname: (name, email_link)
+    for nickname, name, email_link in get_authors()
 }
 
 


### PR DESCRIPTION
By placing an entry into the file `AUTHORS` like so: `Joe Doe(nickname) <joe.doe@example.com>`, Ablog would have enough information to set the authors of the blog and their corresponding nicknames and emails.