### PR TITLE
Adding an isolated page recent_posts

### DIFF
--- a/_templates/recent_posts.html
+++ b/_templates/recent_posts.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+{% include "ablog/recentposts.html" %}
+</body>
+</html>

--- a/conf.py
+++ b/conf.py
@@ -121,6 +121,7 @@ html_sidebars = {
         "ablog/archives.html",
         "searchbox.html",
     ],
+    "recent_posts": [],
 }
 
 # -- Blog Feed Options --------------------------------------------------------
@@ -376,7 +377,9 @@ templates_path = ["_templates"]
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-# html_additional_pages = {}
+html_additional_pages = {
+    "recent_posts": "recent_posts.html",
+}
 
 # If false, no module index is generated.
 # html_domain_indices = True

--- a/recent_posts.md
+++ b/recent_posts.md
@@ -1,0 +1,1 @@
+# Will be replaced by `recent_posts.html`


### PR DESCRIPTION
This page is page is isolated from the doctree and should be consumed by an iframe located at https://python.pe